### PR TITLE
Add ensure_equal to initializer.rb.tt

### DIFF
--- a/lib/generators/data_checks/templates/initializer.rb.tt
+++ b/lib/generators/data_checks/templates/initializer.rb.tt
@@ -12,7 +12,8 @@ DataChecks.configure do
 
   # ==> Configure checks
   #
-  # Available checks are :ensure_no, :ensure_any, :ensure_more, and :ensure_less.
+  # Available checks are :ensure_no, :ensure_any, :ensure_more, :ensure_less,
+  # and :ensure_equal.
   #
   # ensure_no :users_without_emails do
   #   User.where(email: nil).count

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -22,6 +22,15 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file("config/initializers/data_checks.rb") do |content|
       assert_includes content, "DataChecks.configure do"
+      %w[
+        :ensure_no
+        :ensure_any
+        :ensure_more
+        :ensure_less
+        :ensure_equal
+      ].each do |dsl_method_name|
+        assert_includes content, dsl_method_name
+      end
     end
   end
 end

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -22,13 +22,12 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file("config/initializers/data_checks.rb") do |content|
       assert_includes content, "DataChecks.configure do"
-      %w[
-        :ensure_no
-        :ensure_any
-        :ensure_more
-        :ensure_less
-        :ensure_equal
-      ].each do |dsl_method_name|
+      expected_dsl_methods = DataChecks::Config.new
+        .public_methods
+        .select { |dsl_method_name| dsl_method_name.to_s.start_with?("ensure_") }
+        .map(&:to_s)
+
+      expected_dsl_methods.each do |dsl_method_name|
         assert_includes content, dsl_method_name
       end
     end


### PR DESCRIPTION
This PR adds newly-added `ensure_equal` to the inline documentation in a comment in intializer.rb.tt.