### PR TITLE
Test: filter out warnings from the mail gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,10 @@ Style/FetchEnvVar:
 Style/HashSyntax:
   Enabled: false
 
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  AllowInnerSlashes: true
+
 Lint/MissingSuper:
   Enabled: false
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,9 +75,9 @@ DataChecks.configure do
 end
 
 module TestRunWarningFilter
-  # Had some trouble with spurious warnings output in mail v2.8.1 gem. Ignore that, to focus output.
+  # Ignore warnings output from mail v2.8.1 gem.
   def warn(message, category: nil, **kwargs)
-    if %r{gems/mail-.+/lib/}.match?(message)
+    if message =~ /gems\/mail-/
       # ignore
     else
       super
@@ -85,4 +85,3 @@ module TestRunWarningFilter
   end
 end
 Warning.extend TestRunWarningFilter
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -74,14 +74,16 @@ DataChecks.configure do
   self.error_handler = ->(error, context) {}
 end
 
-module TestRunWarningFilter
-  # Ignore warnings output from mail v2.8.1 gem.
-  def warn(message, category: nil, **kwargs)
-    if message =~ /gems\/mail-/
-      # ignore
-    else
-      super
+if defined?(Warning)
+  module TestRunWarningFilter
+    # Ignore warnings output from mail v2.8.1 gem.
+    def warn(message, category: nil, **kwargs)
+      if message =~ /gems\/mail-/
+        # ignore
+      else
+        super
+      end
     end
   end
+  Warning.extend TestRunWarningFilter
 end
-Warning.extend TestRunWarningFilter

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,3 +73,16 @@ DataChecks.configure do
   # Swallow everything to be able to test erroring checks.
   self.error_handler = ->(error, context) {}
 end
+
+module TestRunWarningFilter
+  # Had some trouble with spurious warnings output in mail v2.8.1 gem. Ignore that, to focus output.
+  def warn(message, category: nil, **kwargs)
+    if %r{gems/mail-.+/lib/}.match?(message)
+      # ignore
+    else
+      super
+    end
+  end
+end
+Warning.extend TestRunWarningFilter
+


### PR DESCRIPTION
These warnings are not relevant to the output, but dominate it.

I borrowed the Warning example from the Ruby documentation.